### PR TITLE
Updated runCmorDemo.py to include valid_min,max variable assignment

### DIFF
--- a/demo/runCmorDemo.py
+++ b/demo/runCmorDemo.py
@@ -55,10 +55,16 @@ for axis in axes:
 
 #pdb.set_trace() ; # Debug statement
 
+# Setup units and create variable to write using cmor - see https://cmor.llnl.gov/mydoc_cmor3_api/#cmor_set_variable_attribute
 d.units = outputUnits
 varid   = cmor.variable(outputVarName,d.units,axisIds,missing_value=d.missing)
 values  = np.array(d[:],np.float32)
 
+# Append valid_min and valid_max to variable before writing using cmor - see https://cmor.llnl.gov/mydoc_cmor3_api/#cmor_set_variable_attribute
+cmor.set_variable_attribute(varid,'valid_min',2.0)
+cmor.set_variable_attribute(varid,'valid_max',3.0)
+
+# Prepare variable for writing, then write and close file - see https://cmor.llnl.gov/mydoc_cmor3_api/#cmor_set_variable_attribute
 cmor.set_deflate(varid,1,1,1) ; # shuffle=1,deflate=1,deflate_level=1 - Deflate options compress file data
 cmor.write(varid,values,time_vals=time[:],time_bnds=time.getBounds()) ; # Write variable with time axis
 f.close()


### PR DESCRIPTION
Fix PCMDI/cmor#237

@JimBiardCics this should solve your problem with `valid_min`, `valid_max`, see the revised output below which is generated by the revised [PCMDI/obs4MIPs-cmor-tables/demo/runCmorDemo.py](https://github.com/PCMDI/obs4MIPs-cmor-tables/blob/cmorIssue237_durack1_SetVariableValidMinMax/demo/runCmorDemo.py#L63-L65):
```
netcdf prw_mon_REMSS-PRW-6-6-0_BE_gn_198701-198812 {
dimensions:
	time = UNLIMITED ; // (24 currently)
	lat = 72 ;
	lon = 144 ;
	bnds = 2 ;
variables:
...
	float prw(time, lat, lon) ;
		prw:standard_name = "atmosphere_water_vapor_content" ;
		prw:long_name = "Water Vapor Path" ;
		prw:comment = "vertically integrated through the atmospheric column" ;
		prw:units = "kg m-2" ;
		prw:cell_methods = "area: time: mean" ;
		prw:missing_value = 1.e+20f ;
		prw:_FillValue = 1.e+20f ;
		prw:valid_min = "2.0" ;
		prw:valid_max = "3.0" ;
...
```