### PR TITLE
conversion factor for MSWEP 3 hourly data fixed

### DIFF
--- a/inputs/PCMDI/GloH2O/MSWEP-V280/runCmor_MSWEP-v280.py
+++ b/inputs/PCMDI/GloH2O/MSWEP-V280/runCmor_MSWEP-v280.py
@@ -148,7 +148,7 @@ for yr in lstyrs:  # LOOP OVER YEARS
 
 #  THE UNITS IN THE ORIGINAL FILES DEPEND ON FREQUENCY
    if avgp == 'Daily':  conv = 3600.*24.
-   if avgp == '3hourly':  conv = 3600.*24.*3.
+   if avgp == '3hourly':  conv = 3600.*24./8.
    if avgp == 'Monthly': conv = 1000*3600.*24.*float(endmo) 
    d = np.divide(ddc,conv)
    print('d read',d.shape)

--- a/inputs/PCMDI/GloH2O/MSWEP-V280/runCmor_MSWEP-v280_3hr.py
+++ b/inputs/PCMDI/GloH2O/MSWEP-V280/runCmor_MSWEP-v280_3hr.py
@@ -37,6 +37,7 @@ for i in lsttmp:
 lstyrs.sort()
 
 inputVarName = 'precipitation'
+inputUnits = 'mm/3hr'
 outputVarName = 'pr'
 outputUnits = 'kg m-2 s-1'
 
@@ -53,7 +54,7 @@ for yr in lstyrs:  # LOOP OVER YEARS
    tdc = np.multiply(fc.time.values[:],24)  # days-since to hours-since
    tbds =np.multiply(fc.time_bnds.values[:],24)
    ddc = fc[inputVarName].values
-   conv = 3600.*24.*3.
+   conv = 3600.*24./8.
    d = np.divide(ddc,conv)
    lat = fc.lat
    lon = fc.lon   #.values


### PR DESCRIPTION
MSWEP 3 hourly data has mm/3hr units according to their [technical document](https://www.dropbox.com/s/5r4nnicfe3ft12d/MSWEP_V2_doc.pdf?dl=1), so I am suggesting revising conversion factor to convert [mm/3hr] to [kg m-2 s-1] 

“The precipitation estimates are stored in the precipitation netCDF field (dimensions 1800×3600) in **mm/3-hour**, mm/day, and mm/month units for the **3-hourly**, daily, and monthly data, respectively.”


1 kg m-2 s-1 
= 86400 mm / day
= 86400 mm / 24 hr
= 86400 mm / (8 x 3) hr
= (86400 / 8) mm / 3 hr
= 10800 mm / 3 hr