### PR TITLE
Add DoESS-UCI institution_id entry to JSON

### DIFF
--- a/obs4MIPs_institution_id.json
+++ b/obs4MIPs_institution_id.json
@@ -9,6 +9,7 @@
         "ColumbiaU":"Columbia University, NY, USA",
         "DLR-BIRA":"Deutsches Zentrum fur Luft- und Raumfahrt, Royal Belgian Institute for Space Aeronomy",
         "DOE-ARM":"U.S. Department of Energy, Atmospheric Radiation Measurment Program",
+        "DoESS-UCI":"Department of Earth System Science, University of California, Irvine, USA",
         "DWD":"Deutscher Wetterdienst, Offenbach 63067, Germany",
         "ECMWF":"The European Centre for Medium-Range Weather Forecasts, Shinfield Park, Reading RG2 9AX, UK",
         "ESPRI-IPSL":"Ensemble de Services Pour la Recherche, Institut Pierre Simon Laplace (France)",


### PR DESCRIPTION
DoESS-UCI, Department of Earth System Science, University of California, Irvine, USA added to the obs4MIPS_institution_id.json

Before submitting your pull request be sure that:

1. You haven't deleted any existing information
2. You haven't eliminated unnecessary blank lines or spaces during your work.
   That makes our reviewing work harder and it could introduce unnecessary
   conflicts with other pull requests.

----

*Note*: You can safely remove this text before submitting your work.