### PR TITLE
Fix license CV regex for issue #658

### DIFF
--- a/Tables/obs4MIPs_CV.json
+++ b/Tables/obs4MIPs_CV.json
@@ -142,7 +142,7 @@
             "WUR":"Wageningen Universit, Netherlands"
         },
         "license":[
-            "Data in this file produced by <Your Centre Name> is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses/). Use of the data must be acknowledged following guidelines found at <a URL maintained by you>. Further information about this data, including some limitations, can be found via <some URL maintained by you>."
+            "^Data in this file produced by .* is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses/). Use of the data must be acknowledged following guidelines found at .*. Further information about this data, including some limitations, can be found via .*."
         ],
         "nominal_resolution":[
             "0.5 km",

--- a/demo/Tables/obs4MIPs_CV.json
+++ b/demo/Tables/obs4MIPs_CV.json
@@ -142,7 +142,7 @@
             "WUR":"Wageningen Universit, Netherlands"
         },
         "license":[
-            "Data in this file produced by <Your Centre Name> is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses/). Use of the data must be acknowledged following guidelines found at <a URL maintained by you>. Further information about this data, including some limitations, can be found via <some URL maintained by you>."
+            "^Data in this file produced by .* is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses/). Use of the data must be acknowledged following guidelines found at .*. Further information about this data, including some limitations, can be found via .*."
         ],
         "nominal_resolution":[
             "0.5 km",

--- a/src/writeJson.py
+++ b/src/writeJson.py
@@ -323,12 +323,14 @@ tmp = [['grid_label','https://raw.githubusercontent.com/WCRP-CMIP/CMIP6_CVs/mast
 #==============================================================================
 
 #%% License
-license_ = ('Data in this file produced by <Your Centre Name> is licensed under'
-            ' a Creative Commons Attribution-ShareAlike 4.0 International License'
-            ' (https://creativecommons.org/licenses/). Use of the data must be'
-            ' acknowledged following guidelines found at <a URL maintained by you>.'
-            ' Further information about this data, including some limitations,'
-            ' can be found via <some URL maintained by you>.')
+license_ = (
+    r'^Data in this file produced by .* is licensed under'
+    r' a Creative Commons Attribution-ShareAlike 4.0 International License'
+    r' (https://creativecommons.org/licenses/). Use of the data must be'
+    r' acknowledged following guidelines found at .*.'
+    r' Further information about this data, including some limitations,'
+    r' can be found via .*.'
+)
 
 #%% Nominal resolution
 #%% Product


### PR DESCRIPTION
Addresses the license CV validation issue discussed in #658 by replacing the fixed license template with a regex that allows product-specific centre names and URLs.

Refs #658